### PR TITLE
added zone redundant config to app service plan

### DIFF
--- a/app_service_plans.tf
+++ b/app_service_plans.tf
@@ -11,6 +11,7 @@ module "app_service_plans" {
 
   tags            = try(each.value.tags, null)
   kind            = try(each.value.kind, null)
+  zone_redundant  = try(each.value.zone_redundant, null)
   settings        = each.value
   global_settings = local.global_settings
 }

--- a/modules/webapps/asp/module.tf
+++ b/modules/webapps/asp/module.tf
@@ -16,6 +16,7 @@ resource "azurerm_app_service_plan" "asp" {
   resource_group_name          = var.resource_group_name
   kind                         = try(var.kind, null)
   maximum_elastic_worker_count = lookup(var.settings, "maximum_elastic_worker_count", null)
+  zone_redundant               = try(var.zone_redundant, null)
 
   # For kind=Linux must be set to true and for kind=Windows must be set to false
   reserved         = lookup(var.settings, "reserved", null) == null ? null : var.settings.reserved

--- a/modules/webapps/asp/variables.tf
+++ b/modules/webapps/asp/variables.tf
@@ -26,6 +26,11 @@ variable "kind" {
   default     = "Windows"
 }
 
+variable "zone_redundant" {
+  description = "(Optional) Specifies if the App Service Plan should be Zone Redundant. Changing this forces a new resource to be created."
+  default     = false
+}
+
 variable "global_settings" {
   description = "Global settings object (see module README.md)"
 }


### PR DESCRIPTION
# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
Added missing config to enable zone redundancy for App Service Plan.

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
