### PR TITLE
Revert "Fix custom route table on AzureFirewallSubnet"

### DIFF
--- a/networking.tf
+++ b/networking.tf
@@ -79,7 +79,6 @@ module "virtual_subnets" {
 
 }
 
-# Covers subnets defined via the standalone 'virtual_subnets' block
 resource "azurerm_subnet_route_table_association" "rt" {
   for_each = {
     for key, subnet in local.networking.virtual_subnets : key => subnet
@@ -87,17 +86,6 @@ resource "azurerm_subnet_route_table_association" "rt" {
   }
 
   subnet_id      = lookup(module.virtual_subnets, each.key, null).id
-  route_table_id = module.route_tables[each.value.route_table_key].id
-}
-
-# Covers subnets defined as part of a vnet block
-resource "azurerm_subnet_route_table_association" "rt_nested" {
-  for_each = {
-    for key, subnet in merge(lookup(local.networking.vnets, "subnets", {}), lookup(local.networking.vnets, "specialsubnets", {})) : key => subnet
-    if try(subnet.route_table_key, null) != null
-  }
-
-  subnet_id      = coalesce(lookup(module.networking.subnets, each.key, null), lookup(module.networking.special_subnets, each.key, null)).id
   route_table_id = module.route_tables[each.value.route_table_key].id
 }
 


### PR DESCRIPTION
Reverts weareplanet/terraform-azure-caf#13

This fix was incorrect, we need to loop through each object in `local.networking.vnets` and access the subnets from there. Will update the upstream patch and re submit.