### PR TITLE
Allow same manual cert on multiple AGW listeners

### DIFF
--- a/modules/networking/application_gateway/locals.tf
+++ b/modules/networking/application_gateway/locals.tf
@@ -78,6 +78,17 @@ locals {
     for key, value in local.listeners : [try(value.keyvault_certificate.certificate_key, [])]
   ]))
 
+  manual_certificates = {
+    for cert in distinct(
+      [
+        for key, value in local.listeners : {
+          cert_key = value.keyvault_certificate.certificate_name
+          cert_value = value.keyvault_certificate
+        } if try(value.keyvault_certificate.certificate_name, null) != null
+      ]
+    ) : cert.cert_key => cert.cert_value
+  }
+
   certificate_request_keys = distinct(flatten([
     for key, value in local.listeners : [try(value.keyvault_certificate_request.key, [])]
   ]))


### PR DESCRIPTION
Currently if you supply 2 or more app gateway backends via var.application_gateway_applications that use the same keyvault cert, you will get an error similar to the following::

```
Resource
/subscriptions//resourceGroups//providers/Microsoft.Network/applicationGateways/
has two child resources with the same name (foo-cert)
```

This commit uses a local to gather up the various certs defined in the listener blocks and make sure each is only added once.
