### PR TITLE
workaround script to set ssl policy in application gateway for listeners

### DIFF
--- a/modules/networking/application_gateway/ssl_policy_workaround.tf
+++ b/modules/networking/application_gateway/ssl_policy_workaround.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "ssl_policy_cli" {
+  provisioner "local-exec" {
+    command = "az network application-gateway ssl-policy set --gateway-name ${azurerm_application_gateway.agw.name} --resource-group ${azurerm_application_gateway.agw.resource_group_name} --name AppGwSslPolicy20220101S --policy-type Predefined"
+  }
+}


### PR DESCRIPTION
There seems to be a bug in app_gateway azurerm 2.99 version that always defaults ssl_policy to  'AppGwSslPolicy20150501'. As the workaround script will run az cli command that sets policy to 'AppGwSslPolicy20220101S'.