### PR TITLE
Update attr refs on SQL Server module

### DIFF
--- a/modules/azuread/groups/group.tf
+++ b/modules/azuread/groups/group.tf
@@ -24,4 +24,3 @@ locals {
     data.azuread_user.main[user].object_id
   ]
 }
-

--- a/modules/azuread/groups/output.tf
+++ b/modules/azuread/groups/output.tf
@@ -4,12 +4,10 @@ output "id" {
 
 }
 
-# deprecated
-# output "name" {
-#   description = "The name of the group created."
-#   value       = azuread_group.group.name
-
-# }
+output "display_name" {
+  description = "The name of the group created."
+  value       = azuread_group.group.display_name
+}
 
 output "tenant_id" {
   description = "The tenand_id of the group created."

--- a/modules/databases/mssql_server/server.tf
+++ b/modules/databases/mssql_server/server.tf
@@ -15,9 +15,9 @@ resource "azurerm_mssql_server" "mssql" {
 
     content {
       azuread_authentication_only = try(var.settings.azuread_administrator.azuread_authentication_only, false)
-      login_username              = try(var.settings.azuread_administrator.login_username, try(var.azuread_groups[var.client_config.landingzone_key][var.settings.azuread_administrator.azuread_group_key].name, var.azuread_groups[var.settings.azuread_administrator.lz_key][var.settings.azuread_administrator.azuread_group_key].name))
-      object_id                   = try(var.settings.azuread_administrator.object_id, try(var.azuread_groups[var.client_config.landingzone_key][var.settings.azuread_administrator.azuread_group_key].id, var.azuread_groups[var.settings.azuread_administrator.lz_key][var.settings.azuread_administrator.azuread_group_key].id))
-      tenant_id                   = try(var.settings.azuread_administrator.tenant_id, try(var.azuread_groups[var.client_config.landingzone_key][var.settings.azuread_administrator.azuread_group_key].tenant_id, var.azuread_groups[var.settings.azuread_administrator.lz_key][var.settings.azuread_administrator.azuread_group_key].tenant_id))
+      login_username              = try(var.settings.azuread_administrator.login_username, var.azuread_groups[try(var.settings.azuread_administrator.lz_key, var.client_config.landingzone_key)][var.settings.azuread_administrator.azuread_group_key].display_name)
+      object_id                   = try(var.settings.azuread_administrator.object_id, var.azuread_groups[try(var.settings.azuread_administrator.lz_key, var.client_config.landingzone_key)][var.settings.azuread_administrator.azuread_group_key].id)
+      tenant_id                   = try(var.settings.azuread_administrator.object_id, var.azuread_groups[try(var.settings.azuread_administrator.lz_key, var.client_config.landingzone_key)][var.settings.azuread_administrator.azuread_group_key].tenant_id)
     }
   }
 


### PR DESCRIPTION
The SQL Server module is using a deprecated attribute reference to get Azure AD group information.
This PR fix that.