### PR TITLE
Ignore changes to the log_analytics_destination_type

### DIFF
--- a/modules/diagnostics/module.tf
+++ b/modules/diagnostics/module.tf
@@ -60,4 +60,11 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostics" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # https://github.com/hashicorp/terraform-provider-azurerm/issues/20140
+      log_analytics_destination_type
+    ]
+  }
 }


### PR DESCRIPTION
Every time we run a plan that is using Azure Diagnostics it detects changes to the `log_analytics_destination_type`. It seems to be a bug.

For now, let's ignore these changes.

GitHub issues:
https://github.com/hashicorp/terraform-provider-azurerm/issues/20140
https://github.com/hashicorp/terraform-provider-azurerm/issues/17779