### PR TITLE
Add PG FlexServer to AzureAD roles / Add SP for PG FlexServer

### DIFF
--- a/azuread_roles.tf
+++ b/azuread_roles.tf
@@ -54,3 +54,11 @@ module "azuread_roles_mssql_server" {
   object_id     = module.mssql_servers[each.key].rbac_id
   azuread_roles = each.value.roles
 }
+
+module "azuread_roles_postgresql_flexible_servers" {
+  source   = "./modules/azuread/roles"
+  for_each = try(local.azuread.azuread_roles.postgresql_flexible_servers, {})
+
+  object_id     = module.postgresql_flexible_servers[each.key].rbac_id
+  azuread_roles = each.value.roles
+}

--- a/modules/databases/postgresql_flexible_server/output.tf
+++ b/modules/databases/postgresql_flexible_server/output.tf
@@ -3,6 +3,10 @@ output "location" {
   value       = var.location
 }
 
+output "rbac_id" {
+  value = try(azurerm_postgresql_flexible_server.postgresql.identity[0].principal_id, null)
+}
+
 output "postgresql_flexible_server_administrator_username" {
   description = "Administrator username of PostgreSQL flexible server"
   value       = azurerm_postgresql_flexible_server.postgresql.administrator_login

--- a/postgresql_flexible_servers.tf
+++ b/postgresql_flexible_servers.tf
@@ -15,6 +15,7 @@ module "postgresql_flexible_servers" {
   resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
 
   remote_objects = {
+    azuread_groups      = local.combined_objects_azuread_groups
     subnet_id           = can(each.value.vnet.subnet_key) ? local.combined_objects_networking[try(each.value.vnet.lz_key, local.client_config.landingzone_key)][each.value.vnet.key].subnets[each.value.vnet.subnet_key].id : null
     private_dns_zone_id = can(each.value.private_dns_zone.key) ? local.combined_objects_private_dns[try(each.value.private_dns_zone.lz_key, local.client_config.landingzone_key)][each.value.private_dns_zone.key].id : null
     keyvault_id         = can(each.value.keyvault.key) ? local.combined_objects_keyvaults[try(each.value.keyvault.lz_key, local.client_config.landingzone_key)][each.value.keyvault.key].id : null


### PR DESCRIPTION
Add resource for assigning roles to the Postgres Flexible Server identity.
New resource for setting the Postgres Service Principal when AD auth is enabled