### PR TITLE
Remove deprecated retention policy blocks from diagnostic settings.  …

### DIFF
--- a/modules/diagnostics/module.tf
+++ b/modules/diagnostics/module.tf
@@ -32,15 +32,6 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostics" {
 
     content {
       category = enabled_log.value.0
-
-      dynamic "retention_policy" {
-        for_each = length(enabled_log.value) > 2 ? [1] : []
-
-        content {
-          enabled = try(enabled_log.value.2, false)
-          days    = try(enabled_log.value.3, 0)
-        }
-      }
     }
   }
 
@@ -50,14 +41,6 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostics" {
     content {
       category = metric.value.0
       enabled  = metric.value.1
-
-      dynamic "retention_policy" {
-        for_each = length(metric.value) > 2 ? [1] : []
-        content {
-          enabled = metric.value.2
-          days    = metric.value.3
-        }
-      }
     }
   }
 


### PR DESCRIPTION
…Azure is rejecting the retention_policy blocks in the diagnostic setting resource.

# [Issue-id](https://github.com/aztfmod/terraform-azurerm-caf/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [ ] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
